### PR TITLE
changes to install hps-lcio on mac

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build/
+install/
+target/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 CMAKE_MINIMUM_REQUIRED( VERSION 2.8 FATAL_ERROR )
 ########################################################
 
-
+SET ( CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk )
 
 # project name
 PROJECT( LCIO )
@@ -15,7 +15,6 @@ PROJECT( LCIO )
 SET( LCIO_VERSION_MAJOR 2 )
 SET( LCIO_VERSION_MINOR 7 )
 SET( LCIO_VERSION_PATCH 5 )
-
 
 
 ### DEPENDENCIES ############################################################
@@ -114,8 +113,6 @@ IF( NOT EXISTS ${LCIO_ENV_INIT} )
     )
 
 ENDIF()
-
-
 
 
 ### GENERATE HEADERS ( USING ANT ) ##########################################

--- a/src/cpp/src/UTIL/lXDR.cc
+++ b/src/cpp/src/UTIL/lXDR.cc
@@ -11,7 +11,7 @@
 #include <string.h>
 
 #if defined(__APPLE_CC__)
-#include "/usr/include/sys/types.h"
+#include "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/sys/types.h"
 #endif
 
 #if defined(__linux) || defined(__CYGWIN__) || defined(__APPLE_CC__)


### PR DESCRIPTION
The hard-coded path the system types in [src/cpp/src/UTIL/lXDR.cc](https://github.com/JeffersonLab/hps-lcio/compare/master...sarahgaiser:hps-lcio:master?expand=1#diff-3888551bd57018fb0fc83dd5b92c45cad73e824f5ae1c13ee54e88849f7eea82) is no longer up to date for newer OS versions (starting with macOS Mojave, see [here](https://github.com/curl/curl/issues/3189#issuecomment-434887965)):
- **old version**
```C++
#if defined(__APPLE_CC__)
#include "/usr/include/sys/types.h"
#endif
```
- **new version**; location of these files changed. Here, the path is hard-coded again to the MacOSX12.3 version. Ideally, this would be set dynamically but I don't know how.
```C++
#if defined(__APPLE_CC__)
#include "/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX12.3.sdk/usr/include/sys/types.h"
#endif
```

The gitignore file is added to get rid of the build and install directories.

NOTE: The link in the README is no longer up to date. It would be great if someone could update this (or remove it).